### PR TITLE
CHG reflect cmake_minor_version in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ None
 Role Variables
 --------------
 
-* `cmake_version`  *3.15.4* The version of CMake to fetch from [cmake.org](http://www.cmake.org)
+* `cmake_version`  *3.20* The version of CMake to fetch from [cmake.org](http://www.cmake.org)
+* `cmake_minor_version`  *3* The minor version of CMake to fetch from [cmake.org](http://www.cmake.org)
 * `cmake_dest_dir`  */opt/cmake* Where to install the CMake tarball
 * `cmake_modify_path`  *True* Add CMake's PATH to .bashrc?
 
@@ -29,7 +30,7 @@ Including an example of how to use your role (for instance, with variables passe
 
     - hosts: servers
       roles:
-         - { role: dockpack.base_cmake, cmake_version: 3.15.4 }
+         - { role: dockpack.base_cmake, cmake_version: "3.20" cmake_minor_version: "3" }
 
 License
 -------


### PR DESCRIPTION
The example playbook in the README.md is a bit out of date. 

For one, the cmake version in the example is `3.15.4` even though the default version for this role is `3.20.3`. I updated the example to use this version.

The other issue is that of the `cmake_minor_version`. The example was showing the old way of defining the cmake version with that value.

Also should the `cmake_minor_version` actually be `cmake_patch_version`? I assume this would be a breaking change, so not sure if it is worth doing.