### PR TITLE
CHG catch gotcha with yaml cmake_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Including an example of how to use your role (for instance, with variables passe
 
     - hosts: servers
       roles:
-         - { role: dockpack.base_cmake, cmake_version: 3.20, cmake_patch_version: 5 }
+         - { role: dockpack.base_cmake, cmake_version: "3.20", cmake_patch_version: "5" }
 
 License
 -------


### PR DESCRIPTION
Ok this one is a bit weird. If you put this in yaml:

```yaml
cmake_version: 3.20
```

When parsed that `3.20` will be interpreted as a number not as a string. Therefore, it is loaded as `3.2`. The version of cmake that will be downloaded will then be `3.2.5` instead of the desired `3.20.5`. So when you specify the cmake_version you need this:

```yaml
cmake_version: "3.20"
```

You need to put the value in quotes to avoid this gotcha with the yaml parsing.